### PR TITLE
purging debs to allow apt upgrades

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -188,6 +188,10 @@ chmod ugo+rw -R $PYNQ_JUPYTER_NOTEBOOKS
 systemctl start jupyter.service
 systemctl start pl_server.service
 
+# Purge libdrm-xlnx-dev to allow `apt upgrade`
+apt-get purge -y libdrm-xlnx-dev
+apt-get purge -y libdrm-xlnx-amdgpu1
+
 # Ask to connect to Jupyter
 ip_addr=$(ip addr show eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
 echo -e "${GREEN}PYNQ Installation completed.${NC}\n"


### PR DESCRIPTION
Seeing `apt upgrade` errors after installing Kria-PYNQ.  This is due to upgraded packages post-launch that cause debian conflicts with libdrm-xlnx-dev (and amdgpu1) packages.

This fix allows for apt upgrade to successfully execute after PYNQ is installed.