### PR TITLE
removed purges from install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -188,10 +188,6 @@ chmod ugo+rw -R $PYNQ_JUPYTER_NOTEBOOKS
 systemctl start jupyter.service
 systemctl start pl_server.service
 
-# Purge libdrm-xlnx-dev to allow `apt upgrade`
-apt-get purge -y libdrm-xlnx-dev
-apt-get purge -y libdrm-xlnx-amdgpu1
-
 # Ask to connect to Jupyter
 ip_addr=$(ip addr show eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
 echo -e "${GREEN}PYNQ Installation completed.${NC}\n"


### PR DESCRIPTION
Looks like the xilinx packages have been updated and we don't need the extra purges in the install script anymore to be able to apt upgrade (purges actually cause errors currently https://github.com/Xilinx/Kria-PYNQ/issues/14).

Test steps:
```
sudo snap install xlnx-config --classic
xlnx-config.sysinit
sudo bash install.sh
sudo apt update
sudo apt upgrade
```