### PR TITLE
Move #!/bin/bash to top

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
+#!/bin/bash
+
 # Copyright (C) 2021 Xilinx, Inc
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
### `#!` is not a comment!  
### Nothing should come before the `#!`  

`#!` tells the system which command interpreter this file is a set of commands from at the very beginning of the script.  
`#!` is a two-byte magic number, which is a special indicator of what is an executable shell script.  

What follows immediately is the path, which indicates the location of the program that will interpret the commands in the script, whether it is a shell, program language, or utility.  
This command interpreter executes the commands from the first line of the script, ignoring the comments.  
