### PR TITLE
Resolve home directory assumption in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -83,7 +83,7 @@ popd
 
 ARCH=aarch64
 HOME=/root
-PYNQ_JUPYTER_NOTEBOOKS=/home/$LOGNAME/jupyter_notebooks
+PYNQ_JUPYTER_NOTEBOOKS=$(readlink -f ~)/jupyter_notebooks
 BOARD=$board
 PYNQ_VENV=/usr/local/share/pynq-venv
 


### PR DESCRIPTION
The `install.sh` script makes an assumption that the home directory will be located under `/home/$LOGNAME/...` - this is true on many systems, but not all. The change here is to replace `/home/$LOGNAME` with `$(readlink -f ~)` that resolves the home directory of the user running the installation.