### PR TITLE
fix dpu notebooks copy path for kd240

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -238,7 +238,7 @@ then
       pip3 install -e . --no-build-isolation
       
       # copy the notebooks
-      cp -r pynq_dpu/kd240_notebooks /home/root/jupyter_notebooks/
+      cp -r pynq_dpu/kd240_notebooks /root/jupyter_notebooks/
       cp pynq_dpu/kd240_notebooks/dpu.* /usr/lib
       popd
 fi


### PR DESCRIPTION
Using latest [Ubuntu Server 22.04 image](https://ubuntu.com/download/amd), notebooks get delivered under /root/jupyter_notebooks.

Should address https://github.com/Xilinx/Kria-PYNQ/issues/41. 