### PR TITLE
Numpy 2.0 workaround

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -144,6 +144,10 @@ then
         exit 1
 fi
 
+# Numpy 2.0 workaround:
+# Install latest 1.* numpy so requirement is met for other packages
+python3 -m pip install numpy==1.26.4
+
 # Installing PYNQ-Metadata
 python3 -m pip install pynqmetadata==0.1.2 
 


### PR DESCRIPTION
With latest numpy 2.0 release a lot of python packages that have numpy as a requirement without version specification are breaking, including pynq.

 With this change we force install the latest numpy release before 2.0 so pynq installation successfully finishes. Once the ecosystem has caught up with numpy 2.0 we can revert this.