### PR TITLE
Fix: Enforce global constraints for Numpy and Typing-Extensions (#48, #51)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -144,15 +144,26 @@ then
         exit 1
 fi
 
-# Numpy 2.0 workaround:
+# =========================================================
+# Global Pip Constraints
+# =========================================================
+cat > /tmp/pynq_3.0.1_constraints.txt <<EOT
+numpy==1.26.4
+typing-extensions>=4.6.0
+pynqmetadata==0.1.2
+pynqutils==0.1.1
+pynq==3.0.1
+EOT
+export PIP_CONSTRAINT=/tmp/pynq_3.0.1_constraints.txt
+
 # Install latest 1.* numpy so requirement is met for other packages
-python3 -m pip install numpy==1.26.4
+python3 -m pip install numpy
 
 # Installing PYNQ-Metadata
-python3 -m pip install pynqmetadata==0.1.2 
+python3 -m pip install pynqmetadata 
 
 # Install PYNQ-Utils
-python3 -m pip install pynqutils==0.1.1 
+python3 -m pip install pynqutils 
 
 # PYNQ JUPYTER
 pushd pynq/sdbuild/packages/jupyter
@@ -166,8 +177,8 @@ pushd pynq/sdbuild/packages/libsds
 ./qemu.sh
 popd
 
-# Install PYNQ-3.0.1
-python3 -m pip install pynq==3.0.1
+# Install PYNQ
+python3 -m pip install pynq
 
 ## GCC-MB and XCLBINUTILS
 pushd /tmp


### PR DESCRIPTION
**Summary**
This PR aims to resolve the dependency resolution failures currently affecting the Kria-PYNQ installation process (#48 and #51).

**Changes and Rationale**
While previous efforts (such as #43) successfully identified the numpy version requirement, the sequential nature of this install script allows subsequent pip calls (like opencv-python or pytest) to trigger an upgrade to Numpy 2.0, effectively overriding previous pins.

To ensure environment stability throughout the entire installation lifecycle:

- Centralized Constraints: I have introduced a global PIP_CONSTRAINT manifest. This ensures that every pip command in the script respects the required versions without needing to manually pin every individual install line.

- Numpy Stability (#51): Sets a global requirement for numpy==1.26.4 to maintain compatibility with PYNQ 3.0.1.

- Typing-Extensions Fix (#48): Enforces typing-extensions>=4.6.0 to prevent an automated downgrade that was causing a conflict with exceptiongroup.

- Consolidated Pins: Grouped core PYNQ package versions into the manifest for easier maintenance in the future.

This approach ensures that the environment remains consistent from the first pip call to the last.